### PR TITLE
API Remove explicit requirement for silverstripe/mimevalidator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
         "cwp/cwp-core": "2.x-dev",
         "silverstripe/auditor": "2.x-dev",
         "silverstripe/environmentcheck": "2.x-dev",
-        "silverstripe/hybridsessions": "2.x-dev",
-        "silverstripe/mimevalidator": "2.x-dev"
+        "silverstripe/hybridsessions": "2.x-dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"


### PR DESCRIPTION
This will now be handled by https://github.com/silverstripe/recipe-core/pull/53

# Parent issue
* https://github.com/silverstripe/silverstripe-framework/issues/8782