### PR TITLE
DEP Fix dependencies to reflect next-minor branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,11 @@
     "license": "BSD-3-Clause",
     "require": {
         "silverstripe/recipe-plugin": "^1",
-        "silverstripe/recipe-core": "4.7.x-dev",
-        "cwp/cwp-core": "2.7.x-dev",
-        "silverstripe/auditor": "2.2.x-dev",
-        "silverstripe/environmentcheck": "2.2.x-dev",
-        "silverstripe/hybridsessions": "2.2.x-dev"
+        "silverstripe/recipe-core": "4.x-dev",
+        "cwp/cwp-core": "2.x-dev",
+        "silverstripe/auditor": "2.x-dev",
+        "silverstripe/environmentcheck": "2.x-dev",
+        "silverstripe/hybridsessions": "2.x-dev"
     },
     "require-dev": {
         "sminnee/phpunit": "^5.7"


### PR DESCRIPTION
The `2` branch should always retain next-minor requirements. This is easy to miss when merging up after a new minor is shipped.